### PR TITLE
feat: make the hooks wallet ready

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -37,7 +37,7 @@ import { useInterval } from "usehooks-ts";
 
 const Home: NextPage = () => {
   const { address } = useAccount();
-  const { data: w3iClient, isLoading: w3iClientIsLoading } =
+  const { isLoading: w3iClientIsLoading } =
     useWeb3InboxClient();
   const { isRegistered } = useWeb3InboxAccount(
     address ? `eip155:1:${address}` : undefined

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -255,7 +255,7 @@ const Home: NextPage = () => {
                     <span>useSubscribe</span>
                     <Button
                       leftIcon={<FaBell />}
-                      onClick={subscribe}
+                      onClick={() => subscribe()}
                       colorScheme="cyan"
                       rounded="full"
                       variant="outline"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @web3inbox/core
 
+## 1.2.0
+
+### Minor Changes
+
+- Feature complete for wallets
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.2.0-1b3d9b8",
+  "version": "1.2.0-7fe8f3d",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@walletconnect/core": "2.11.0",
-    "@walletconnect/notify-client": "^1.1.1",
+    "@walletconnect/notify-client": "^1.1.2",
     "valtio": "^1.11.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.2.0-5bd35d2",
+  "version": "1.2.0-1b3d9b8",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.1.0",
+  "version": "1.2.0-5bd35d2",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.2.0-7fe8f3d",
+  "version": "1.1.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -39,11 +39,12 @@ export class Web3InboxClient {
     registration: undefined,
   });
 
-  public constructor(
+  private constructor(
     private notifyClient: NotifyClient,
     private domain: string,
     private allApps: boolean,
-    private rpcUrlBuilder: (chainId: string) => string
+    private rpcUrlBuilder: (chainId: string) => string,
+    private projectId: string
   ) {}
 
   private getRequiredAccountParam(account?: string) {
@@ -246,7 +247,8 @@ export class Web3InboxClient {
       // isLimited is defaulted to true, therefore null/undefined values are defaulted to true.
       params.allApps ?? false,
       params.rpcUrlBuilder
-	?? ((chainId: string) => `${DEFAULT_RPC_URL}?projectId=${params.projectId}&chainId=${chainId}`)
+	?? ((chainId: string) => `${DEFAULT_RPC_URL}?projectId=${params.projectId}&chainId=${chainId}`),
+      params.projectId
     );
 
     Web3InboxClient.subscriptionState.subscriptions =
@@ -732,10 +734,9 @@ export class Web3InboxClient {
    *
    */
   public async registerWithPushServer(token: string, type: "fcm" | "apns" = "fcm") {
-    const projectId = this.notifyClient.core.projectId
     const clientId = await this.notifyClient.core.crypto.getClientId()
 
-    const echoUrl = `${ECHO_URL}/${projectId}/clients`
+    const echoUrl = `${ECHO_URL}/${this.projectId}/clients`
 
     const echoResponse = await fetch(echoUrl, {
       method: 'POST',

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -478,7 +478,6 @@ export class Web3InboxClient {
     // Get the initial next page
     nextPage();
 
-
     return (
       onNotificationDataUpdate: (
         notificationData: GetNotificationsReturn

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -434,9 +434,7 @@ export class Web3InboxClient {
         account,
         domain
       );
-      console.log(">>>", { fetchedNotificationData })
       const notification = fetchedNotificationData.notifications.shift();
-      console.log(">>> notify_message > notif", notification)
       if (notification && !currentNotificationIds.has(notification.id)) {
         data.notifications = [notification, ...data.notifications];
         currentNotificationIds.add(notification.id);
@@ -528,12 +526,6 @@ export class Web3InboxClient {
       accountOrInternalAccount,
       domain ?? this.domain
     );
-
-    console.log(">>> fetching with", {
-      topic: sub?.topic,
-      limit,
-      startingAfter,
-    })
 
     if (sub) {
       try {

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -731,8 +731,9 @@ export class Web3InboxClient {
    * @param {string} token - APNS or FCM token.
    * @param {string} [type] - Whether the token is APNS or FCM. Defaulted to fcm.
    *
+   * @returns {string} clientId - Client ID that successfully registered with echo
    */
-  public async registerWithPushServer(token: string, type: "fcm" | "apns" = "fcm") {
+  public async registerWithPushServer(token: string, type: "fcm" | "apns" = "fcm"): Promise<string> {
     const clientId = await this.notifyClient.core.crypto.getClientId()
 
     const echoUrl = `${ECHO_URL}/${this.projectId}/clients`
@@ -750,7 +751,7 @@ export class Web3InboxClient {
     })
 
     if (echoResponse.status === 200) {
-      return true;
+      return clientId;
     }
 
     throw new Error(`Registration with push server failed, status: ${echoResponse.status}, response: ${await echoResponse.text()}`)

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @web3inbox/react
 
+## 1.2.0
+
+### Minor Changes
+
+- Feature complete for wallets
+- Expose `getSubscription` and add optional overrides in `subscribe`
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.2.0-5fd9098",
+  "version": "1.2.0-2fe9a9d",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.2.0-2fe9a9d",
+  "version": "1.1.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.1.0",
+  "version": "1.2.0-5bd35d2",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.2.0-5bd35d2",
+  "version": "1.2.0-5fd9098",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -99,6 +99,12 @@ export const useNotifications = (
     });
   };
 
+  // If the domain of the account change, all previous data is invalidated.
+  useEffect(() => {
+    setData([])
+    setHasMore(false)
+  }, [domain, account])
+
   if (isLoadingNextPage) {
     return {
       data,

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 import type { NotifyClientTypes } from "@walletconnect/notify-client";
 import { useEffect, useState } from "react";
-import { ErrorOf, HooksReturn, LoadingOf, SuccessOf } from "../types/hooks";
+import { ErrorOf, HooksReturn, SuccessOf } from "../types/hooks";
 import { useWeb3InboxClient } from "./useWeb3InboxClient";
 
 const waitFor = async (condition: () => boolean) => {
@@ -51,6 +51,7 @@ export const useNotifications = (
     if (!w3iClient) return;
 
     try {
+      setIsLoadingNextPage(true);
       const { nextPage: nextPageFunc, stopWatchingNotifications } =
         w3iClient.pageNotifications(
           notificationsPerPage,
@@ -59,6 +60,7 @@ export const useNotifications = (
           domain
         )((data) => {
           setData(data.notifications);
+	  setIsLoadingNextPage(false);
           setHasMore(data.hasMore);
         });
 

--- a/packages/react/src/hooks/useSubscribe.ts
+++ b/packages/react/src/hooks/useSubscribe.ts
@@ -5,7 +5,7 @@ import { Web3InboxClient } from "@web3inbox/core";
 
 type UseSubscribeReturn = HooksReturn<
   boolean,
-  { subscribe: () => ReturnType<Web3InboxClient["subscribeToDapp"]> }
+  { subscribe: (accountOverride?: string, domainOverride?: string) => ReturnType<Web3InboxClient["subscribeToDapp"]> }
 >;
 
 /**
@@ -24,7 +24,7 @@ export const useSubscribe = (
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const subscribe = async () => {
+  const subscribe = async (accountOverride?: string, domainOverride?: string) => {
     setError(null);
     setIsLoading(true);
 
@@ -36,7 +36,7 @@ export const useSubscribe = (
       }
 
       return await w3iClient
-        .subscribeToDapp(account, domain)
+        .subscribeToDapp(accountOverride ?? account, domainOverride ?? domain)
         .then((res) => {
           setData(true);
           resolve(res);

--- a/packages/react/src/hooks/useSubscription.ts
+++ b/packages/react/src/hooks/useSubscription.ts
@@ -70,6 +70,6 @@ export const useSubscription = (
     error: null,
     isLoading: false,
     watching,
-    getSubscription: w3iClient!.getSubscription
+    getSubscription: (account, domain) => w3iClient!.getSubscription(account, domain)
   } as SuccessOf<UseSubscriptionReturn>;
 };

--- a/packages/react/src/hooks/useSubscription.ts
+++ b/packages/react/src/hooks/useSubscription.ts
@@ -6,7 +6,10 @@ import { useWeb3InboxClient } from "./useWeb3InboxClient";
 type SubscriptionState = NotifyClientTypes.NotifySubscription | null;
 type UseSubscriptionReturn = HooksReturn<
   SubscriptionState,
-  { watching: boolean }
+  {
+    watching: boolean,
+    getSubscription: (account?: string, domain?: string) => SubscriptionState
+  }
 >;
 
 /**
@@ -30,7 +33,7 @@ export const useSubscription = (
     if (w3iClient && !isLoadingClient) {
       setSubscription(w3iClient.getSubscription(account, domain));
     }
-  }, [w3iClient, isLoadingClient]);
+  }, [w3iClient, domain, account, isLoadingClient]);
 
   useEffect(() => {
     if (!w3iClient || watching) return;
@@ -58,6 +61,7 @@ export const useSubscription = (
       error: null,
       isLoading: true,
       watching: false,
+      getSubscription: () => null
     } as LoadingOf<UseSubscriptionReturn>;
   }
 
@@ -66,5 +70,6 @@ export const useSubscription = (
     error: null,
     isLoading: false,
     watching,
+    getSubscription: w3iClient!.getSubscription
   } as SuccessOf<UseSubscriptionReturn>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,6 +3137,22 @@
     axios "^1.4.0"
     jwt-decode "^3.1.2"
 
+"@walletconnect/notify-client@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-1.1.2.tgz#c9655f2c7cf742be41200313eeb68968ccda7e14"
+  integrity sha512-M96SzudXYO7qTXjZaOpylKCdp1NPpH+xmc03ai/3zlmQgAz9ftWDbDgiTG1s3wzUJjJYxNHXtqLBkwxD5h4t6w==
+  dependencies:
+    "@noble/ed25519" "^1.7.3"
+    "@walletconnect/cacao" "1.0.2"
+    "@walletconnect/core" "^2.11.0-canary.0"
+    "@walletconnect/did-jwt" "2.0.1"
+    "@walletconnect/identity-keys" "^2.0.1"
+    "@walletconnect/jsonrpc-utils" "1.0.7"
+    "@walletconnect/time" "1.0.2"
+    "@walletconnect/utils" "^2.11.0"
+    axios "^1.4.0"
+    jwt-decode "^3.1.2"
+
 "@walletconnect/relay-api@^1.0.9":
   version "1.0.9"
   resolved "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz"
@@ -3279,6 +3295,22 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.1"
     tslib "1.14.1"
+
+"@web3inbox/core@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@web3inbox/core/-/core-1.1.0.tgz#f00a13f37d186ddd61e5dcfe32feed63372fda23"
+  integrity sha512-dckukl3H3r9TZ7rFXpQeIbLbofdtPo3h8+s3LfADonPQx8ZahRZJSgmN8pre5lZnMz8AmBsbd8ehtpcH/h+aaA==
+  dependencies:
+    "@walletconnect/core" "2.11.0"
+    "@walletconnect/notify-client" "^1.1.1"
+    valtio "^1.11.2"
+
+"@web3inbox/react@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@web3inbox/react/-/react-1.1.0.tgz#01d3276bfea76c4d2f89080963c5e9ab08f83dde"
+  integrity sha512-A3pVpYt6UUPkyJfx4y67OJXX5BpqgUm2UIyxFhA74rmwvsEWTdp4nGkdM7KMBQshHjZ4m95sOMSAETK0+0O9PQ==
+  dependencies:
+    react "^18.2.0"
 
 "@web3modal/common@4.0.0-alpha.0":
   version "4.0.0-alpha.0"


### PR DESCRIPTION
## Bug Fixes
- Fix memory leak in `useNotifications` -> `client.pageNotifications` because the event listener was not being `off`d when `stopWatchNotifications` was called
- Fix loading states when fetching next page. Resolves #73 
- Fix bug where sometimes receiving a message doesn't cause a refresh in notification state 

## Additions
- add `registerWithPushServer` function to allow registration to echo
- `subscribe` from `useSubscribe` now accepts optional override parameters for account and domain. This will allow subscriptions to different dapps
- `useSubscription` now exposes `getSubscription` which accepts `account` and `domain` to allow fetching info about a specific subscription

## Changes
- `Web3InboxClient.constructor` is now `private` as opposed to `public`. This is "technically" a breaking change but not really because not using `init` is undocumented and unsupported as `init` manages initialization of state
