### PR TITLE
Fix/data overwrite use notifications

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.3.0-a8e32fb",
+  "version": "1.3.0-6d359e8",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -427,7 +427,7 @@ export class Web3InboxClient {
    * @param {boolean} [unreadFirst] - Should unread notifications be ordered on top regardless of recency
    * @param {boolean} [onRead] - Function to call when reading a message
    *
-   * @returns {Object[]} messages  - Message Record array
+   * @returns {Object[]} Notifications  - Notification Record array
    */
   public pageNotifications(
     notificationsPerPage: number,
@@ -632,7 +632,7 @@ export class Web3InboxClient {
    * @param {boolean} [unreadFirst] - Should unread notifications be ordered on top regardless of recency
    * @param {boolean} [onRead] - Function to call when reading a message
    *
-   * @returns {Object[]} messages  - Message Record array
+   * @returns {Object[]} notifications  - Notification Record array
    */
   public getNotificationHistory(
     limit: number,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.3.0-a8e32fb",
+  "version": "1.3.0-6d359e8",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -39,6 +39,7 @@ type UseNotificationsReturn = HooksReturn<
  * @param {boolean} [isInfiniteScroll] - Whether or not to keep old notifications in the return array or just the current page
  * @param {string} [account] - Account to get subscriptions notifications from, defaulted to current account
  * @param {string} [domain] - Domain to get subscription notifications from, defaulted to one set in init.
+ * @param {boolean} [unreadFirst] - Should unread notifications be ordered on top regardless of recency
  */
 export const useNotifications = (
   notificationsPerPage: number,


### PR DESCRIPTION
- Pass `onRead` functionality into `core` which achieves 3 things:
  1. Cleans up the responsibility and data management from `react` to `core`
  2. Fixes a bug where upon calling `nextPage` all read statuses are reset
  3. Allows users of the SDK to pass their own functions to hook into `read`
- Fix bug where `unreadFirst` was ignored on `nextPage`
- Expose `hasMoreUnread` in `useNotifications` 