### PR TITLE
Feat/queue mark as read

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.3.0-dcd5756",
+  "version": "1.3.0-6ac7f1e",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.3.0-a93f013",
+  "version": "1.3.0-dcd5756",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -599,6 +599,7 @@ export class Web3InboxClient {
     for(const notificationId of notificationIds) {
       Web3InboxClient.notificationsToRead.add(notificationId)
     } 
+
     this.debouncedMarkNotificationsAsRead(Array.from(Web3InboxClient.notificationsToRead.values()), account, domain)
   }
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -9,6 +9,7 @@ import { proxySet } from "valtio/utils";
 import { createPromiseWithTimeout } from "../utils/promiseTimeout";
 import { isSmartWallet } from "../utils/address";
 import { version as web3inboxCorePackageVersion, name as web3inboxCorePackageName } from '../../package.json'
+import { debounce } from 'lodash'
 
 const DEFAULT_RPC_URL = "https://rpc.walletconnect.com/v1/";
 
@@ -42,6 +43,9 @@ export class Web3InboxClient {
     account: undefined,
     registration: undefined,
   });
+
+  private MARK_NOTIFICATIONS_AS_READ_DEBOUNCE_TIME = 50;
+  private static notificationsToRead = proxySet<string>([])
 
   private constructor(
     private notifyClient: NotifyClient,
@@ -539,17 +543,11 @@ export class Web3InboxClient {
     };
   }
 
-  /**
-   * Mark specified notifications as read for a account & domain subscription
-   * @param {string[]} notificationIds - Account to get subscription message history for, defaulted to current account
-   * @param {string} [account] - Account to get subscription message history for, defaulted to current account
-   * @param {string} [domain] - Domain to get subscription message history for, defaulted to one set in init.
-   */
-  public markNotificationsAsRead(
+  private debouncedMarkNotificationsAsRead = debounce((
     notificationIds: string[],
     account?: string,
     domain?: string
-  ) {
+  ) => {
     const accountOrInternalAccount = this.getRequiredAccountParam(account);
 
     if (!accountOrInternalAccount) {
@@ -585,6 +583,23 @@ export class Web3InboxClient {
         }`
       );
     }
+  }, this.MARK_NOTIFICATIONS_AS_READ_DEBOUNCE_TIME)
+
+  /**
+   * Mark specified notifications as read for a account & domain subscription
+   * @param {string[]} notificationIds - Account to get subscription message history for, defaulted to current account
+   * @param {string} [account] - Account to get subscription message history for, defaulted to current account
+   * @param {string} [domain] - Domain to get subscription message history for, defaulted to one set in init.
+   */
+  public markNotificationsAsRead(
+    notificationIds: string[],
+    account?: string,
+    domain?: string
+  ) {
+    for(const notificationId of notificationIds) {
+      Web3InboxClient.notificationsToRead.add(notificationId)
+    } 
+    this.debouncedMarkNotificationsAsRead(Array.from(Web3InboxClient.notificationsToRead.values()), account, domain)
   }
 
   /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.3.0-a93f013",
+  "version": "1.3.0-981e2b6",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -126,23 +126,21 @@ export const useNotifications = (
     await waitFor(() => Boolean(w3iClient));
     const w3iClientTruthy = w3iClient as Web3InboxClient;
 
-    w3iClientTruthy
-      .markNotificationsAsRead(notificationIds, account, domain)
-      .catch(setError)
-      .then(() => {
-        setData((notifications) =>
-          notifications.map((notification) => {
-            if (notificationIds.includes(notification.id)) {
-              return {
-                ...notification,
-                isRead: true,
-              };
-            } else {
-              return notification;
-            }
-          })
-        );
-      });
+    w3iClientTruthy.markNotificationsAsRead(notificationIds, account, domain)
+
+    // Optimistically update the data
+    setData((notifications) =>
+      notifications.map((notification) => {
+        if (notificationIds.includes(notification.id)) {
+          return {
+            ...notification,
+            isRead: true,
+          };
+        } else {
+          return notification;
+        }
+      })
+    );
   };
 
   const markAllNotificationsAsRead = async () => {


### PR DESCRIPTION
- Resolves #82 
- Changes `markNotificationsAsRead` to return `void` as it now simply calls a debounced function

> [!WARNING]
> Not ready for review