### PR TITLE
Fix/prevent spam of read

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "1.3.0-a93f013",
+  "version": "1.3.0-069f40b",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -221,7 +221,7 @@ export class Web3InboxClient {
     projectId: string;
     domain?: string;
     allApps?: boolean;
-    logLevel?: "error" | "info" | "debug";
+    logLevel?: "error" | "info" | "debug" | "trace";
     rpcUrlBuilder?: Web3InboxClient["rpcUrlBuilder"];
     sdkVersionMapEntries?: Record<string, string>
   }): Promise<Web3InboxClient> {
@@ -470,6 +470,11 @@ export class Web3InboxClient {
 
     const onReadWrapper = (notification: NotifyClientTypes.NotifyNotification) => {
       if(readNotifications[notification.id]) return;
+
+      if(notification.isRead) {
+        readNotifications[notification.id] = true;
+	return;
+      }
 
       this.markNotificationsAsRead(
         [notification.id],

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -448,7 +448,7 @@ export class Web3InboxClient {
     unreadFirst: boolean = true,
     onRead: (notificationId: string) => void = () => {}
   ): (
-    onNotificationDataUpdate: (notificationData: GetNotificationsReturn) => void
+    onNotificationDataUpdate: (notificationData: PageNotificationsReturn) => void
   ) => {
     stopWatchingNotifications: () => void;
     data: PageNotificationsReturn;
@@ -540,7 +540,7 @@ export class Web3InboxClient {
 
     return (
       onNotificationDataUpdate: (
-        notificationData: GetNotificationsReturn
+        notificationData: PageNotificationsReturn
       ) => void
     ) => {
       const unsub = subscribe(data, () => {

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -676,6 +676,7 @@ export class Web3InboxClient {
               notifications: notifications.map((notification) => ({
                 ...notification,
                 read: () => {
+		  if (notification.isRead) return;
 		  if (onRead) onRead(notification.id);
                   this.markNotificationsAsRead(
                     [notification.id],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/react",
-  "version": "1.3.0-a93f013",
+  "version": "1.3.0-069f40b",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -123,24 +123,21 @@ export const useNotifications = (
     await waitFor(() => Boolean(w3iClient));
     const w3iClientTruthy = w3iClient as Web3InboxClient;
 
-    w3iClientTruthy
-      .markNotificationsAsRead(notificationIds, account, domain)
-      .catch(setError)
-      .then(() => {
-        setDataWrapper(({data: notifications}) => ({
-	  data: notifications.map((notification) => {
-            if (notificationIds.includes(notification.id)) {
-              return {
-                ...notification,
-                isRead: true,
-              };
-            } else {
-              return notification;
-            }
-          })
-	})
-        );
-      });
+    w3iClientTruthy.markNotificationsAsRead(notificationIds, account, domain)
+
+    // Optimistic data updates
+    setDataWrapper(({data: notifications}) => ({
+      data: notifications.map((notification) => {
+        if (notificationIds.includes(notification.id)) {
+          return {
+            ...notification,
+            isRead: true,
+          };
+        } else {
+          return notification;
+        }
+      })
+    }));
   };
 
   const markAllNotificationsAsRead = async () => {

--- a/packages/react/src/utils/initWeb3InboxClient.ts
+++ b/packages/react/src/utils/initWeb3InboxClient.ts
@@ -5,7 +5,7 @@ interface IInitWeb3InboxClient {
   projectId: string;
   domain?: string;
   allApps?: boolean;
-  logLevel?: "info" | "error" | "debug";
+  logLevel?: "info" | "error" | "debug" | "trace";
   rpcUrlBuilder?: (chainId: string) => string;
 }
 


### PR DESCRIPTION
- Resolves #82 
- Changes `markNotificationsAsRead` to return `void` as it now simply calls a debounced function
- Prevent spam of notifications already read
